### PR TITLE
implement VARCHAR and TEXT string types with validation, collation, serialization, and tests

### DIFF
--- a/internal/types/text.go
+++ b/internal/types/text.go
@@ -1,0 +1,299 @@
+package types
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+const MAX_TEXT_LENGTH = 65535
+
+type TextType struct {
+	collation string
+}
+
+func (t *TextType) Metadata() *TypeMetadata {
+	return &TypeMetadata{
+		ID:        TypeIDText,
+		Name:      "TEXT",
+		Size:      -1,
+		Alignment: 1,
+	}
+}
+
+func NewTextType(collation string) *TextType {
+	if collation == "" {
+		collation = "utf8_general_ci"
+	}
+	return &TextType{
+		collation: collation,
+	}
+}
+
+type TextValue struct {
+	Value  string
+	IsNull bool
+}
+
+func (t *TextType) Collation() string {
+	return t.collation
+}
+
+func (t *TextType) Validate(value interface{}) error {
+	if value == nil {
+		return nil
+	}
+
+	str, ok := value.(string)
+	if !ok {
+		return NewValidationError(fmt.Sprintf("expected string, got %T", value))
+	}
+
+	if !utf8.ValidString(str) {
+		return NewValidationError("invalid UTF-8 sequence")
+	}
+
+	if len(str) > MAX_TEXT_LENGTH {
+		return NewValidationError("text too large (max 65535 bytes)")
+	}
+	return nil
+}
+
+func (t *TextType) IsNull(value interface{}) bool {
+	return value == nil
+}
+
+func (t *TextType) NullValue() interface{} {
+	return nil
+}
+
+func (t *TextType) Size(value interface{}) int {
+	if t.IsNull(value) {
+		return 1
+	}
+
+	str, ok := value.(string)
+	if !ok {
+		return 0
+	}
+	// Todo:  Variable length encoding
+	return 4 + len(str)
+}
+
+func (t *TextType) String() string {
+	return "TEXT"
+}
+
+func (t *TextType) Serialize(value interface{}) ([]byte, error) {
+	if t.IsNull(value) {
+		return []byte{0xFF}, nil
+	}
+
+	str, ok := value.(string)
+	if !ok {
+		return nil, NewValidationError(fmt.Sprintf("expected string, got %T", value))
+	}
+
+	if err := t.Validate(value); err != nil {
+		return nil, err
+	}
+
+	data := make([]byte, 4+len(str))
+
+	binary.BigEndian.PutUint32(data[:4], uint32(len(str)))
+
+	copy(data[4:], str)
+
+	return data, nil
+}
+
+func (t *TextType) Deserialize(data []byte) (interface{}, error) {
+	if len(data) == 0 {
+		return nil, NewValidationError("empty data")
+	}
+
+	if len(data) == 1 && data[0] == 0xFF {
+		return nil, nil
+	}
+
+	if len(data) < 4 {
+		return nil, NewValidationError("insufficient data for length prefix")
+	}
+
+	length := binary.BigEndian.Uint32(data[:4])
+
+	if len(data) < int(4+length) {
+		return nil, NewValidationError("data shorter than declared length")
+	}
+
+	str := string(data[4 : 4+length])
+
+	if err := t.Validate(str); err != nil {
+		return nil, err
+	}
+
+	return str, nil
+}
+
+func (t *TextType) SerializeJSON(value interface{}) ([]byte, error) {
+	if t.IsNull(value) {
+		return []byte("null"), nil
+	}
+
+	str, ok := value.(string)
+	if !ok {
+		return nil, NewValidationError(fmt.Sprintf("expected string, got %T", value))
+	}
+
+	if err := t.Validate(value); err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(str)
+}
+
+func (t *TextType) DeserializeJSON(data []byte) (interface{}, error) {
+	var str *string
+	if err := json.Unmarshal(data, &str); err != nil {
+		return nil, NewValidationError(fmt.Sprintf("invalid JSON: %v", err))
+	}
+
+	if str == nil {
+		return nil, nil
+	}
+
+	if err := t.Validate(*str); err != nil {
+		return nil, err
+	}
+
+	return *str, nil
+}
+
+func (t *TextType) SerializeText(value interface{}) (string, error) {
+	if t.IsNull(value) {
+		return "NULL", nil
+	}
+
+	str, ok := value.(string)
+	if !ok {
+		return "", NewValidationError(fmt.Sprintf("expected string, got %T", value))
+	}
+
+	if err := t.Validate(value); err != nil {
+		return "", err
+	}
+
+	escaped := strings.ReplaceAll(str, "'", "''")
+
+	return "'" + escaped + "'", nil
+}
+
+func (t *TextType) DeserializeText(text string) (interface{}, error) {
+	text = strings.TrimSpace(text)
+
+	if strings.ToUpper(text) == "NULL" {
+		return nil, nil
+	}
+
+	if len(text) < 2 || !strings.HasPrefix(text, "'") || !strings.HasSuffix(text, "'") {
+		return nil, NewValidationError("expected quoted string")
+	}
+
+	str := text[1 : len(text)-1]
+	str = strings.ReplaceAll(str, "''", "'") // Unescape single quotes
+
+	if err := t.Validate(str); err != nil {
+		return nil, err
+	}
+
+	return str, nil
+}
+
+func (t *TextType) unicodeCompare(a, b string) int {
+	runesA := []rune(a)
+	runesB := []rune(b)
+
+	minLen := len(runesA)
+	if len(runesB) < minLen {
+		minLen = len(runesB)
+	}
+
+	for i := 0; i < minLen; i++ {
+		if runesA[i] != runesB[i] {
+			normA := unicode.ToLower(runesA[i])
+			normB := unicode.ToLower(runesB[i])
+
+			if normA < normB {
+				return -1
+			}
+			if normA > normB {
+				return 1
+			}
+		}
+	}
+
+	if len(runesA) < len(runesB) {
+		return -1
+	}
+	if len(runesA) > len(runesB) {
+		return 1
+	}
+
+	return 0
+}
+
+func (t *TextType) Compare(a, b interface{}) int {
+	aNull := t.IsNull(a)
+	bNull := t.IsNull(b)
+
+	if aNull && bNull {
+		return 0
+	}
+	if aNull {
+		return -1
+	}
+	if bNull {
+		return 1
+	}
+
+	strA, okA := a.(string)
+	strB, okB := b.(string)
+
+	if !okA || !okB {
+		strA = fmt.Sprintf("%v", a)
+		strB = fmt.Sprintf("%v", b)
+	}
+
+	return t.compareWithCollation(strA, strB)
+}
+
+func (t *TextType) compareWithCollation(a, b string) int {
+	switch t.collation {
+	case "utf8_bin", "binary":
+		return strings.Compare(a, b)
+
+	case "utf8_general_ci", "utf8_unicode_ci":
+		return strings.Compare(strings.ToLower(a), strings.ToLower(b))
+
+	case "utf8_unicode_520_ci":
+		return t.unicodeCompare(a, b)
+
+	default:
+		return strings.Compare(strings.ToLower(a), strings.ToLower(b))
+	}
+}
+
+func (t *TextType) SetCollation(collation string) {
+	t.collation = collation
+}
+
+func (t *TextType) GetCollation() string {
+	return t.collation
+}
+
+func (t *TextType) IsCaseSensitive() bool {
+	return strings.Contains(t.collation, "_bin") || t.collation == "binary"
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -22,7 +22,7 @@ const (
 	TypeIDFloat32
 	TypeIDFloat64
 	TypeIDText
-	TypeIDVarChar
+	TypeIDVarchar
 	TypeIDTimestamp
 	TypeIDDate
 	TypeIDTime

--- a/internal/types/varchar.go
+++ b/internal/types/varchar.go
@@ -1,0 +1,309 @@
+package types
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+const MAX_VARCHAR_LENGTH int = 255
+
+type VarcharType struct {
+	maxLength int
+	collation string
+}
+
+func NewVarcharType(maxLength int, collation string) *VarcharType {
+	if maxLength <= 0 {
+		maxLength = MAX_VARCHAR_LENGTH
+	}
+	if collation == "" {
+		collation = "utf8_general_ci"
+	}
+	return &VarcharType{
+		maxLength: maxLength,
+		collation: collation,
+	}
+}
+
+func (t *VarcharType) Metadata() *TypeMetadata {
+	return &TypeMetadata{
+		ID:        TypeIDVarchar,
+		Name:      fmt.Sprintf("VARCHAR(%d)", t.maxLength),
+		Size:      -1,
+		Alignment: 1,
+	}
+}
+
+type VarcharValue struct {
+	Value  string
+	Length int
+	IsNull bool
+}
+
+func (t *VarcharType) MaxLength() int {
+	return t.maxLength
+}
+
+func (t *VarcharType) Collation() string {
+	return t.collation
+}
+
+func (t *VarcharType) Validate(value interface{}) error {
+	if value == nil {
+		return nil
+	}
+	str, ok := value.(string)
+	if !ok {
+		return NewValidationError(fmt.Sprintf("expected string, got %T", value))
+	}
+
+	if !utf8.ValidString(str) {
+		return NewValidationError("invalid UTF-8 sequence")
+	}
+
+	runeCount := utf8.RuneCountInString(str)
+	if runeCount > t.maxLength {
+		return NewValidationError(fmt.Sprintf("string length %d exceeds maximum %d", runeCount, t.maxLength))
+	}
+
+	return nil
+}
+
+func (t *VarcharType) IsNull(value interface{}) bool {
+	return value == nil
+}
+
+func (t *VarcharType) NullValue() interface{} {
+	return nil
+}
+
+func (t *VarcharType) Size(value interface{}) int {
+	if t.IsNull(value) {
+		return 1
+	}
+
+	str, ok := value.(string)
+	if !ok {
+		return 0
+	}
+	// Todo: Variable length encoding
+	return 4 + len(str)
+}
+
+func (t *VarcharType) String() string {
+	return fmt.Sprintf("VARCHAR(%d)", t.maxLength)
+}
+
+func (t *VarcharType) Serialize(value interface{}) ([]byte, error) {
+	if t.IsNull(value) {
+		return []byte{0xFF}, nil
+	}
+
+	str, ok := value.(string)
+	if !ok {
+		return nil, NewValidationError(fmt.Sprintf("expected string, got %T", value))
+	}
+
+	if err := t.Validate(value); err != nil {
+		return nil, err
+	}
+
+	data := make([]byte, 4+len(str))
+
+	binary.BigEndian.PutUint32(data[:4], uint32(len(str)))
+	copy(data[4:], str)
+
+	return data, nil
+}
+
+func (t *VarcharType) Deserialize(data []byte) (interface{}, error) {
+	if len(data) == 0 {
+		return nil, NewValidationError("empty data")
+	}
+
+	if len(data) == 1 && data[0] == 0xFF {
+		return nil, nil
+	}
+
+	if len(data) < 4 {
+		return nil, NewValidationError("insufficient data for length prefix")
+	}
+
+	length := binary.BigEndian.Uint32(data[:4])
+
+	if len(data) < int(4+length) {
+		return nil, NewValidationError("data shorter than declared length")
+	}
+
+	str := string(data[4 : 4+length])
+	if err := t.Validate(str); err != nil {
+		return nil, err
+	}
+
+	return str, nil
+}
+
+func (t *VarcharType) SerializeJSON(value interface{}) ([]byte, error) {
+	if t.IsNull(value) {
+		return []byte("null"), nil
+	}
+
+	str, ok := value.(string)
+	if !ok {
+		return nil, NewValidationError(fmt.Sprintf("expected string, got %T", value))
+	}
+
+	if err := t.Validate(value); err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(str)
+}
+
+func (t *VarcharType) DeserializeJSON(data []byte) (interface{}, error) {
+	var str *string
+
+	if err := json.Unmarshal(data, &str); err != nil {
+		return nil, NewValidationError(fmt.Sprintf("invalid JSON: %v", err))
+	}
+
+	if str == nil {
+		return nil, nil
+	}
+
+	if err := t.Validate(*str); err != nil {
+		return nil, err
+	}
+
+	return *str, nil
+}
+
+func (t *VarcharType) SerializeText(value interface{}) (string, error) {
+	if t.IsNull(value) {
+		return "NULL", nil
+	}
+
+	str, ok := value.(string)
+	if !ok {
+		return "", NewValidationError(fmt.Sprintf("expected string, got %T", value))
+	}
+
+	if err := t.Validate(value); err != nil {
+		return "", err
+	}
+
+	escaped := strings.ReplaceAll(str, "'", "''")
+
+	return "'" + escaped + "'", nil
+}
+
+func (t *VarcharType) DeserializeText(text string) (interface{}, error) {
+	text = strings.TrimSpace(text)
+
+	if strings.ToUpper(text) == "NULL" {
+		return nil, nil
+	}
+
+	if len(text) < 2 || !strings.HasPrefix(text, "'") || !strings.HasSuffix(text, "'") {
+		return nil, NewValidationError("expected quoted string")
+	}
+
+	str := text[1 : len(text)-1]
+	str = strings.ReplaceAll(str, "''", "'") // Unescape single quotes
+
+	if err := t.Validate(str); err != nil {
+		return nil, err
+	}
+
+	return str, nil
+}
+
+func (t *VarcharType) unicodeCompare(a, b string) int {
+	runesA := []rune(a)
+	runesB := []rune(b)
+
+	minLen := len(runesA)
+	if len(runesB) < minLen {
+		minLen = len(runesB)
+	}
+
+	for i := 0; i < minLen; i++ {
+		if runesA[i] != runesB[i] {
+			normA := unicode.ToLower(runesA[i])
+			normB := unicode.ToLower(runesB[i])
+
+			if normA < normB {
+				return -1
+			}
+			if normA > normB {
+				return 1
+			}
+		}
+	}
+
+	if len(runesA) < len(runesB) {
+		return -1
+	}
+	if len(runesA) > len(runesB) {
+		return 1
+	}
+
+	return 0
+}
+
+func (t *VarcharType) Compare(a, b interface{}) int {
+	aNull := t.IsNull(a)
+	bNull := t.IsNull(b)
+
+	if aNull && bNull {
+		return 0
+	}
+	if aNull {
+		return -1
+	}
+	if bNull {
+		return 1
+	}
+
+	strA, okA := a.(string)
+	strB, okB := b.(string)
+
+	if !okA || !okB {
+		strA = fmt.Sprintf("%v", a)
+		strB = fmt.Sprintf("%v", b)
+	}
+
+	return t.compareWithCollation(strA, strB)
+}
+
+func (t *VarcharType) compareWithCollation(a, b string) int {
+	switch t.collation {
+	case "utf8_bin", "binary":
+		return strings.Compare(a, b)
+
+	case "utf8_general_ci", "utf8_unicode_ci":
+		return strings.Compare(strings.ToLower(a), strings.ToLower(b))
+
+	case "utf8_unicode_520_ci":
+		return t.unicodeCompare(a, b)
+
+	default:
+		return strings.Compare(strings.ToLower(a), strings.ToLower(b))
+	}
+}
+
+func (t *VarcharType) SetCollation(collation string) {
+	t.collation = collation
+}
+
+func (t *VarcharType) GetCollation() string {
+	return t.collation
+}
+
+func (t *VarcharType) IsCaseSensitive() bool {
+	return strings.Contains(t.collation, "_bin") || t.collation == "binary"
+}

--- a/tests/benchmark/types/text_benchmark_test.go
+++ b/tests/benchmark/types/text_benchmark_test.go
@@ -1,0 +1,212 @@
+package types_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/khalid64/kongdb/internal/types"
+)
+
+func BenchmarkTextType_Serialize(b *testing.B) {
+	text := types.NewTextType("utf8_general_ci")
+	value := "hello world"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := text.Serialize(value)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkTextType_Deserialize(b *testing.B) {
+	text := types.NewTextType("utf8_general_ci")
+	value := "hello world"
+	data, _ := text.Serialize(value)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := text.Deserialize(data)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkTextType_Compare(b *testing.B) {
+	text := types.NewTextType("utf8_general_ci")
+	a := "hello world"
+	b_val := "hello universe"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		text.Compare(a, b_val)
+	}
+}
+
+func BenchmarkTextType_Validate(b *testing.B) {
+	text := types.NewTextType("utf8_general_ci")
+	value := "hello world"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := text.Validate(value)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkTextType_LargeString(b *testing.B) {
+	text := types.NewTextType("utf8_general_ci")
+	value := strings.Repeat("hello world ", 1000) // ~12KB
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := text.Serialize(value)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkTextType_VeryLargeString(b *testing.B) {
+	text := types.NewTextType("utf8_general_ci")
+	value := strings.Repeat("hello world ", 5000) // ~60KB
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := text.Serialize(value)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkTextType_JSONSerialize(b *testing.B) {
+	text := types.NewTextType("utf8_general_ci")
+	value := "hello world"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := text.SerializeJSON(value)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkTextType_JSONDeserialize(b *testing.B) {
+	text := types.NewTextType("utf8_general_ci")
+	value := "hello world"
+	data, _ := text.SerializeJSON(value)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := text.DeserializeJSON(data)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkTextType_TextSerialize(b *testing.B) {
+	text := types.NewTextType("utf8_general_ci")
+	value := "hello world"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := text.SerializeText(value)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkTextType_TextDeserialize(b *testing.B) {
+	text := types.NewTextType("utf8_general_ci")
+	value := "hello world"
+	textStr, _ := text.SerializeText(value)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := text.DeserializeText(textStr)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkTextType_UnicodeString(b *testing.B) {
+	text := types.NewTextType("utf8_general_ci")
+	value := "café über naïve"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := text.Serialize(value)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkTextType_LargeUnicodeString(b *testing.B) {
+	text := types.NewTextType("utf8_general_ci")
+	value := strings.Repeat("café über naïve ", 1000) // ~18KB of Unicode
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := text.Serialize(value)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkTextType_CaseInsensitiveCompare(b *testing.B) {
+	text := types.NewTextType("utf8_general_ci")
+	a := "Hello World"
+	b_val := "hello world"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		text.Compare(a, b_val)
+	}
+}
+
+func BenchmarkTextType_CaseSensitiveCompare(b *testing.B) {
+	text := types.NewTextType("utf8_bin")
+	a := "Hello World"
+	b_val := "hello world"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		text.Compare(a, b_val)
+	}
+}
+
+func BenchmarkTextType_LargeStringCompare(b *testing.B) {
+	text := types.NewTextType("utf8_general_ci")
+	a := strings.Repeat("hello world ", 100)
+	b_val := strings.Repeat("hello universe ", 100)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		text.Compare(a, b_val)
+	}
+}
+
+func BenchmarkTextType_MemoryUsage(b *testing.B) {
+	text := types.NewTextType("utf8_general_ci")
+	value := strings.Repeat("hello world ", 1000)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := text.Serialize(value)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/tests/benchmark/types/varchar_benchmark_test.go
+++ b/tests/benchmark/types/varchar_benchmark_test.go
@@ -1,0 +1,161 @@
+package types_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/khalid64/kongdb/internal/types"
+)
+
+func BenchmarkVarcharType_Serialize(b *testing.B) {
+	varchar := types.NewVarcharType(255, "utf8_general_ci")
+	value := "hello world"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := varchar.Serialize(value)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkVarcharType_Deserialize(b *testing.B) {
+	varchar := types.NewVarcharType(255, "utf8_general_ci")
+	value := "hello world"
+	data, _ := varchar.Serialize(value)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := varchar.Deserialize(data)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkVarcharType_Compare(b *testing.B) {
+	varchar := types.NewVarcharType(255, "utf8_general_ci")
+	a := "hello world"
+	b_val := "hello universe"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		varchar.Compare(a, b_val)
+	}
+}
+
+func BenchmarkVarcharType_Validate(b *testing.B) {
+	varchar := types.NewVarcharType(255, "utf8_general_ci")
+	value := "hello world"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := varchar.Validate(value)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkVarcharType_LargeString(b *testing.B) {
+	varchar := types.NewVarcharType(1000, "utf8_general_ci")
+	value := strings.Repeat("hello world ", 50) // ~600 characters
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := varchar.Serialize(value)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkVarcharType_JSONSerialize(b *testing.B) {
+	varchar := types.NewVarcharType(255, "utf8_general_ci")
+	value := "hello world"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := varchar.SerializeJSON(value)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkVarcharType_JSONDeserialize(b *testing.B) {
+	varchar := types.NewVarcharType(255, "utf8_general_ci")
+	value := "hello world"
+	data, _ := varchar.SerializeJSON(value)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := varchar.DeserializeJSON(data)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkVarcharType_TextSerialize(b *testing.B) {
+	varchar := types.NewVarcharType(255, "utf8_general_ci")
+	value := "hello world"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := varchar.SerializeText(value)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkVarcharType_TextDeserialize(b *testing.B) {
+	varchar := types.NewVarcharType(255, "utf8_general_ci")
+	value := "hello world"
+	textStr, _ := varchar.SerializeText(value)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := varchar.DeserializeText(textStr)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkVarcharType_UnicodeString(b *testing.B) {
+	varchar := types.NewVarcharType(255, "utf8_general_ci")
+	value := "café über naïve"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := varchar.Serialize(value)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkVarcharType_CaseInsensitiveCompare(b *testing.B) {
+	varchar := types.NewVarcharType(255, "utf8_general_ci")
+	a := "Hello World"
+	b_val := "hello world"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		varchar.Compare(a, b_val)
+	}
+}
+
+func BenchmarkVarcharType_CaseSensitiveCompare(b *testing.B) {
+	varchar := types.NewVarcharType(255, "utf8_bin")
+	a := "Hello World"
+	b_val := "hello world"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		varchar.Compare(a, b_val)
+	}
+}

--- a/tests/integration/types/string_types_test.go
+++ b/tests/integration/types/string_types_test.go
@@ -1,0 +1,295 @@
+package integration_test
+
+import (
+	"testing"
+
+	"github.com/khalid64/kongdb/internal/types"
+)
+
+func TestStringTypes_Integration(t *testing.T) {
+	// Test type registry integration
+	varchar := types.NewVarcharType(255, "utf8_general_ci")
+	text := types.NewTextType("utf8_general_ci")
+
+	err := types.RegisterGlobal(varchar)
+	if err != nil {
+		t.Fatalf("failed to register varchar: %v", err)
+	}
+
+	err = types.RegisterGlobal(text)
+	if err != nil {
+		t.Fatalf("failed to register text: %v", err)
+	}
+
+	// Test retrieval
+	retrievedVarchar, exists := types.GetGlobalByID(types.TypeIDVarchar)
+	if !exists {
+		t.Fatal("varchar type not found in registry")
+	}
+
+	if retrievedVarchar.String() != varchar.String() {
+		t.Errorf("retrieved varchar doesn't match original")
+	}
+
+	retrievedText, exists := types.GetGlobalByID(types.TypeIDText)
+	if !exists {
+		t.Fatal("text type not found in registry")
+	}
+
+	if retrievedText.String() != text.String() {
+		t.Errorf("retrieved text doesn't match original")
+	}
+
+	// Test round-trip serialization
+	testValue := "hello world"
+
+	data, err := varchar.Serialize(testValue)
+	if err != nil {
+		t.Fatalf("serialization failed: %v", err)
+	}
+
+	result, err := varchar.Deserialize(data)
+	if err != nil {
+		t.Fatalf("deserialization failed: %v", err)
+	}
+
+	if result != testValue {
+		t.Errorf("round-trip failed: expected %v, got %v", testValue, result)
+	}
+}
+
+func TestStringTypes_CrossTypeCompatibility(t *testing.T) {
+	varchar := types.NewVarcharType(255, "utf8_general_ci")
+	text := types.NewTextType("utf8_general_ci")
+
+	// Test that both types can handle the same data
+	testValues := []string{
+		"",
+		"hello",
+		"café",
+		"Hello World",
+		"string with 'quotes'",
+		"unicode: 你好世界",
+	}
+
+	for _, value := range testValues {
+		t.Run(value, func(t *testing.T) {
+			// Test VARCHAR
+			if err := varchar.Validate(value); err != nil {
+				t.Errorf("varchar validation failed: %v", err)
+			}
+
+			varcharData, err := varchar.Serialize(value)
+			if err != nil {
+				t.Errorf("varchar serialization failed: %v", err)
+				return
+			}
+
+			varcharResult, err := varchar.Deserialize(varcharData)
+			if err != nil {
+				t.Errorf("varchar deserialization failed: %v", err)
+				return
+			}
+
+			if varcharResult != value {
+				t.Errorf("varchar round-trip failed: expected %v, got %v", value, varcharResult)
+			}
+
+			// Test TEXT
+			if err := text.Validate(value); err != nil {
+				t.Errorf("text validation failed: %v", err)
+			}
+
+			textData, err := text.Serialize(value)
+			if err != nil {
+				t.Errorf("text serialization failed: %v", err)
+				return
+			}
+
+			textResult, err := text.Deserialize(textData)
+			if err != nil {
+				t.Errorf("text deserialization failed: %v", err)
+				return
+			}
+
+			if textResult != value {
+				t.Errorf("text round-trip failed: expected %v, got %v", value, textResult)
+			}
+		})
+	}
+}
+
+func TestStringTypes_CollationCompatibility(t *testing.T) {
+	// Test different collations
+	collations := []string{
+		"utf8_general_ci",
+		"utf8_bin",
+		"utf8_unicode_ci",
+	}
+
+	testPairs := []struct {
+		a, b     string
+		expected int
+	}{
+		{"hello", "HELLO", 0}, // Should be equal in case-insensitive
+		{"hello", "world", -1},
+		{"world", "hello", 1},
+	}
+
+	for _, collation := range collations {
+		t.Run(collation, func(t *testing.T) {
+			varchar := types.NewVarcharType(255, collation)
+			text := types.NewTextType(collation)
+
+			for _, pair := range testPairs {
+				varcharResult := varchar.Compare(pair.a, pair.b)
+				textResult := text.Compare(pair.a, pair.b)
+
+				// Both types should behave the same with same collation
+				if varcharResult != textResult {
+					t.Errorf("collation mismatch: varchar=%d, text=%d for %s vs %s",
+						varcharResult, textResult, pair.a, pair.b)
+				}
+
+				// For case-insensitive collations, "hello" and "HELLO" should be equal
+				if collation != "utf8_bin" && pair.a == "hello" && pair.b == "HELLO" {
+					if varcharResult != 0 {
+						t.Errorf("case-insensitive comparison failed: %d", varcharResult)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestStringTypes_JSONCompatibility(t *testing.T) {
+	varchar := types.NewVarcharType(255, "utf8_general_ci")
+	text := types.NewTextType("utf8_general_ci")
+
+	testValues := []interface{}{
+		"hello",
+		"café",
+		"string with \"quotes\"",
+		nil,
+	}
+
+	for _, value := range testValues {
+		t.Run("varchar", func(t *testing.T) {
+			jsonData, err := varchar.SerializeJSON(value)
+			if err != nil {
+				t.Errorf("varchar JSON serialization failed: %v", err)
+				return
+			}
+
+			result, err := varchar.DeserializeJSON(jsonData)
+			if err != nil {
+				t.Errorf("varchar JSON deserialization failed: %v", err)
+				return
+			}
+
+			if value != result {
+				t.Errorf("varchar JSON round-trip failed: expected %v, got %v", value, result)
+			}
+		})
+
+		t.Run("text", func(t *testing.T) {
+			jsonData, err := text.SerializeJSON(value)
+			if err != nil {
+				t.Errorf("text JSON serialization failed: %v", err)
+				return
+			}
+
+			result, err := text.DeserializeJSON(jsonData)
+			if err != nil {
+				t.Errorf("text JSON deserialization failed: %v", err)
+				return
+			}
+
+			if value != result {
+				t.Errorf("text JSON round-trip failed: expected %v, got %v", value, result)
+			}
+		})
+	}
+}
+
+func TestStringTypes_TextSerializationCompatibility(t *testing.T) {
+	varchar := types.NewVarcharType(255, "utf8_general_ci")
+	text := types.NewTextType("utf8_general_ci")
+
+	testValues := []interface{}{
+		"hello",
+		"café",
+		"string with 'quotes'",
+		nil,
+	}
+
+	for _, value := range testValues {
+		t.Run("varchar", func(t *testing.T) {
+			textStr, err := varchar.SerializeText(value)
+			if err != nil {
+				t.Errorf("varchar text serialization failed: %v", err)
+				return
+			}
+
+			result, err := varchar.DeserializeText(textStr)
+			if err != nil {
+				t.Errorf("varchar text deserialization failed: %v", err)
+				return
+			}
+
+			if value != result {
+				t.Errorf("varchar text round-trip failed: expected %v, got %v", value, result)
+			}
+		})
+
+		t.Run("text", func(t *testing.T) {
+			textStr, err := text.SerializeText(value)
+			if err != nil {
+				t.Errorf("text text serialization failed: %v", err)
+				return
+			}
+
+			result, err := text.DeserializeText(textStr)
+			if err != nil {
+				t.Errorf("text text deserialization failed: %v", err)
+				return
+			}
+
+			if value != result {
+				t.Errorf("text text round-trip failed: expected %v, got %v", value, result)
+			}
+		})
+	}
+}
+
+func TestStringTypes_PerformanceComparison(t *testing.T) {
+	varchar := types.NewVarcharType(255, "utf8_general_ci")
+	text := types.NewTextType("utf8_general_ci")
+
+	// Test that both types have similar performance characteristics
+	testValue := "hello world"
+
+	// Measure serialization performance
+	varcharData, err := varchar.Serialize(testValue)
+	if err != nil {
+		t.Fatalf("varchar serialization failed: %v", err)
+	}
+
+	textData, err := text.Serialize(testValue)
+	if err != nil {
+		t.Fatalf("text serialization failed: %v", err)
+	}
+
+	// Both should produce similar sized data for same input
+	if len(varcharData) != len(textData) {
+		t.Errorf("data size mismatch: varchar=%d, text=%d", len(varcharData), len(textData))
+	}
+
+	// Both should have same size calculation
+	varcharSize := varchar.Size(testValue)
+	textSize := text.Size(testValue)
+
+	if varcharSize != textSize {
+		t.Errorf("size calculation mismatch: varchar=%d, text=%d", varcharSize, textSize)
+	}
+}

--- a/tests/unit/types/text_test.go
+++ b/tests/unit/types/text_test.go
@@ -1,0 +1,239 @@
+package types_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/khalid64/kongdb/internal/types"
+)
+
+func TestTextType_Metadata(t *testing.T) {
+	text := types.NewTextType("utf8_general_ci")
+	metadata := text.Metadata()
+
+	if metadata.ID != types.TypeIDText {
+		t.Errorf("expected TypeIDText, got %d", metadata.ID)
+	}
+
+	if metadata.Name != "TEXT" {
+		t.Errorf("expected TEXT, got %s", metadata.Name)
+	}
+
+	if metadata.Size != -1 {
+		t.Errorf("expected -1 for variable size, got %d", metadata.Size)
+	}
+}
+
+func TestTextType_Validate(t *testing.T) {
+	text := types.NewTextType("utf8_general_ci")
+
+	tests := []struct {
+		name    string
+		value   interface{}
+		wantErr bool
+	}{
+		{"valid string", "hello", false},
+		{"empty string", "", false},
+		{"large string", strings.Repeat("a", 1000), false},
+		{"unicode string", "café", false},
+		{"null value", nil, false},
+		{"wrong type", 123, true},
+		{"too large", strings.Repeat("a", 70000), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := text.Validate(tt.value)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestTextType_Serialize(t *testing.T) {
+	text := types.NewTextType("utf8_general_ci")
+
+	tests := []struct {
+		name    string
+		value   interface{}
+		wantErr bool
+	}{
+		{"normal string", "hello", false},
+		{"empty string", "", false},
+		{"unicode string", "café", false},
+		{"large string", strings.Repeat("a", 1000), false},
+		{"null value", nil, false},
+		{"invalid value", 123, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := text.Serialize(tt.value)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Serialize() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				// Test deserialization
+				result, err := text.Deserialize(data)
+				if err != nil {
+					t.Errorf("Deserialize() error = %v", err)
+					return
+				}
+
+				if tt.value == nil {
+					if result != nil {
+						t.Errorf("expected nil, got %v", result)
+					}
+				} else {
+					if result != tt.value {
+						t.Errorf("expected %v, got %v", tt.value, result)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestTextType_JSON(t *testing.T) {
+	text := types.NewTextType("utf8_general_ci")
+
+	tests := []struct {
+		name    string
+		value   interface{}
+		wantErr bool
+	}{
+		{"normal string", "hello", false},
+		{"string with quotes", "hello 'world'", false},
+		{"unicode string", "café", false},
+		{"large string", strings.Repeat("a", 1000), false},
+		{"null value", nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := text.SerializeJSON(tt.value)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SerializeJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				result, err := text.DeserializeJSON(data)
+				if err != nil {
+					t.Errorf("DeserializeJSON() error = %v", err)
+					return
+				}
+
+				if tt.value == nil {
+					if result != nil {
+						t.Errorf("expected nil, got %v", result)
+					}
+				} else {
+					if result != tt.value {
+						t.Errorf("expected %v, got %v", tt.value, result)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestTextType_Compare(t *testing.T) {
+	text := types.NewTextType("utf8_general_ci")
+
+	tests := []struct {
+		name string
+		a    interface{}
+		b    interface{}
+		want int
+	}{
+		{"hello < world", "hello", "world", -1},
+		{"hello = hello", "hello", "hello", 0},
+		{"world > hello", "world", "hello", 1},
+		{"null < string", nil, "hello", -1},
+		{"string > null", "hello", nil, 1},
+		{"null = null", nil, nil, 0},
+		{"case insensitive", "Hello", "hello", 0},
+		{"large strings", strings.Repeat("a", 100), strings.Repeat("b", 100), -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := text.Compare(tt.a, tt.b)
+			if result != tt.want {
+				t.Errorf("Compare() = %d, want %d", result, tt.want)
+			}
+		})
+	}
+}
+
+func TestTextType_Size(t *testing.T) {
+	text := types.NewTextType("utf8_general_ci")
+
+	tests := []struct {
+		name  string
+		value interface{}
+		want  int
+	}{
+		{"empty string", "", 4},
+		{"hello", "hello", 9},
+		{"unicode", "café", 9},
+		{"large string", strings.Repeat("a", 1000), 1004},
+		{"null", nil, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := text.Size(tt.value)
+			if result != tt.want {
+				t.Errorf("Size() = %d, want %d", result, tt.want)
+			}
+		})
+	}
+}
+
+func TestTextType_TextSerialization(t *testing.T) {
+	text := types.NewTextType("utf8_general_ci")
+
+	tests := []struct {
+		name    string
+		value   interface{}
+		wantErr bool
+	}{
+		{"normal string", "hello", false},
+		{"string with quotes", "hello 'world'", false},
+		{"unicode string", "café", false},
+		{"null value", nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			textStr, err := text.SerializeText(tt.value)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SerializeText() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				result, err := text.DeserializeText(textStr)
+				if err != nil {
+					t.Errorf("DeserializeText() error = %v", err)
+					return
+				}
+
+				if tt.value == nil {
+					if result != nil {
+						t.Errorf("expected nil, got %v", result)
+					}
+				} else {
+					if result != tt.value {
+						t.Errorf("expected %v, got %v", tt.value, result)
+					}
+				}
+			}
+		})
+	}
+}

--- a/tests/unit/types/types_test.go
+++ b/tests/unit/types/types_test.go
@@ -141,7 +141,7 @@ func TestTypeRegistry(t *testing.T) {
 
 	mockType2 := &MockType{
 		metadata: &types.TypeMetadata{
-			ID:        types.TypeIDVarChar,
+			ID:        types.TypeIDVarchar,
 			Name:      "VARCHAR",
 			Size:      -1,
 			Alignment: 1,
@@ -166,7 +166,7 @@ func TestTypeRegistry(t *testing.T) {
 	assert.True(t, exists)
 	assert.Equal(t, mockType1, typ)
 
-	typ, exists = registry.GetByID(types.TypeIDVarChar)
+	typ, exists = registry.GetByID(types.TypeIDVarchar)
 	assert.True(t, exists)
 	assert.Equal(t, mockType2, typ)
 
@@ -301,7 +301,7 @@ func TestTypeUtilityFunctions(t *testing.T) {
 
 	variableType := &MockType{
 		metadata: &types.TypeMetadata{
-			ID:   types.TypeIDVarChar,
+			ID:   types.TypeIDVarchar,
 			Name: "VARCHAR",
 			Size: -1,
 		},
@@ -356,7 +356,7 @@ func TestTypeIDSerialization(t *testing.T) {
 		types.TypeIDUnknown,
 		types.TypeIDBool,
 		types.TypeIDInt32,
-		types.TypeIDVarChar,
+		types.TypeIDVarchar,
 		types.TypeIDText,
 	}
 

--- a/tests/unit/types/varchar_test.go
+++ b/tests/unit/types/varchar_test.go
@@ -1,0 +1,192 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/khalid64/kongdb/internal/types"
+)
+
+func TestVarcharType_Metadata(t *testing.T) {
+	varchar := types.NewVarcharType(255, "utf8_general_ci")
+	metadata := varchar.Metadata()
+
+	if metadata.ID != types.TypeIDVarchar {
+		t.Errorf("expected TypeIDVarchar, got %d", metadata.ID)
+	}
+
+	if metadata.Name != "VARCHAR(255)" {
+		t.Errorf("expected VARCHAR(255), got %s", metadata.Name)
+	}
+
+	if metadata.Size != -1 {
+		t.Errorf("expected -1 for variable size, got %d", metadata.Size)
+	}
+}
+
+func TestVarcharType_Validate(t *testing.T) {
+	varchar := types.NewVarcharType(10, "utf8_general_ci")
+
+	tests := []struct {
+		name    string
+		value   interface{}
+		wantErr bool
+	}{
+		{"valid string", "hello", false},
+		{"empty string", "", false},
+		{"max length", "1234567890", false},
+		{"too long", "12345678901", true},
+		{"null value", nil, false},
+		{"wrong type", 123, true},
+		{"unicode string", "café", false},
+		{"unicode too long", "caféééééééééé", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := varchar.Validate(tt.value)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestVarcharType_Serialize(t *testing.T) {
+	varchar := types.NewVarcharType(255, "utf8_general_ci")
+
+	tests := []struct {
+		name    string
+		value   interface{}
+		wantErr bool
+	}{
+		{"normal string", "hello", false},
+		{"empty string", "", false},
+		{"unicode string", "café", false},
+		{"null value", nil, false},
+		{"invalid value", 123, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := varchar.Serialize(tt.value)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Serialize() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				// Test deserialization
+				result, err := varchar.Deserialize(data)
+				if err != nil {
+					t.Errorf("Deserialize() error = %v", err)
+					return
+				}
+
+				if tt.value == nil {
+					if result != nil {
+						t.Errorf("expected nil, got %v", result)
+					}
+				} else {
+					if result != tt.value {
+						t.Errorf("expected %v, got %v", tt.value, result)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestVarcharType_JSON(t *testing.T) {
+	varchar := types.NewVarcharType(255, "utf8_general_ci")
+
+	tests := []struct {
+		name    string
+		value   interface{}
+		wantErr bool
+	}{
+		{"normal string", "hello", false},
+		{"string with quotes", "hello 'world'", false},
+		{"unicode string", "café", false},
+		{"null value", nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := varchar.SerializeJSON(tt.value)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SerializeJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				result, err := varchar.DeserializeJSON(data)
+				if err != nil {
+					t.Errorf("DeserializeJSON() error = %v", err)
+					return
+				}
+
+				if tt.value == nil {
+					if result != nil {
+						t.Errorf("expected nil, got %v", result)
+					}
+				} else {
+					if result != tt.value {
+						t.Errorf("expected %v, got %v", tt.value, result)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestVarcharType_Compare(t *testing.T) {
+	varchar := types.NewVarcharType(255, "utf8_general_ci")
+
+	tests := []struct {
+		name string
+		a    interface{}
+		b    interface{}
+		want int
+	}{
+		{"hello < world", "hello", "world", -1},
+		{"hello = hello", "hello", "hello", 0},
+		{"world > hello", "world", "hello", 1},
+		{"null < string", nil, "hello", -1},
+		{"string > null", "hello", nil, 1},
+		{"null = null", nil, nil, 0},
+		{"case insensitive", "Hello", "hello", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := varchar.Compare(tt.a, tt.b)
+			if result != tt.want {
+				t.Errorf("Compare() = %d, want %d", result, tt.want)
+			}
+		})
+	}
+}
+
+func TestVarcharType_Size(t *testing.T) {
+	varchar := types.NewVarcharType(255, "utf8_general_ci")
+
+	tests := []struct {
+		name  string
+		value interface{}
+		want  int
+	}{
+		{"empty string", "", 4},
+		{"hello", "hello", 9},
+		{"unicode", "café", 9},
+		{"null", nil, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := varchar.Size(tt.value)
+			if result != tt.want {
+				t.Errorf("Size() = %d, want %d", result, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR implements comprehensive support for VARCHAR and TEXT string types in KongDB, including:

- VARCHAR(n) with length validation and collation support
- TEXT type for unlimited length strings (up to 65,535 bytes)
- UTF-8 encoding and proper validation
- Binary, JSON, and text serialization
- Efficient memory management for variable-length strings
- String comparison and collation (case-insensitive, case-sensitive, Unicode)
- Comprehensive unit tests and performance benchmarks
- Integration tests for type registry and compatibility

Closes: #11